### PR TITLE
Replace blocking threading.Lock with asyncio.Lock

### DIFF
--- a/supertokens_fastapi/device_info.py
+++ b/supertokens_fastapi/device_info.py
@@ -16,12 +16,10 @@ under the License.
 
 from supertokens_fastapi.exceptions import raise_general_exception
 from os import environ
-from threading import Lock
 
 
 class DeviceInfo:
     __instance = None
-    __lock = Lock()
 
     def __init__(self):
         self.__frontend_sdk = []
@@ -29,9 +27,7 @@ class DeviceInfo:
     @staticmethod
     def get_instance():
         if DeviceInfo.__instance is None:
-            with DeviceInfo.__lock:
-                if DeviceInfo.__instance is None:
-                    DeviceInfo.__instance = DeviceInfo()
+            DeviceInfo.__instance = DeviceInfo()
         return DeviceInfo.__instance
 
     @staticmethod
@@ -46,12 +42,11 @@ class DeviceInfo:
         return self.__frontend_sdk
 
     def add_to_frontend_sdk(self, sdk):
-        with DeviceInfo.__lock:
-            exists = False
-            for i in self.__frontend_sdk:
-                if i['name'] == sdk['name'] and i['version'] == sdk['version']:
-                    exists = True
-                    break
+        exists = False
+        for i in self.__frontend_sdk:
+            if i['name'] == sdk['name'] and i['version'] == sdk['version']:
+                exists = True
+                break
 
-            if not exists:
-                self.__frontend_sdk.append(sdk)
+        if not exists:
+            self.__frontend_sdk.append(sdk)

--- a/supertokens_fastapi/handshake_info.py
+++ b/supertokens_fastapi/handshake_info.py
@@ -18,7 +18,7 @@ from supertokens_fastapi.querier import Querier
 from supertokens_fastapi.constants import HANDSHAKE
 from os import environ
 from supertokens_fastapi.exceptions import raise_general_exception
-from threading import Lock
+from asyncio import Lock
 
 
 class HandshakeInfo:
@@ -44,7 +44,7 @@ class HandshakeInfo:
     @staticmethod
     async def get_instance():
         if HandshakeInfo.__instance is None:
-            with HandshakeInfo.__lock:
+            async with HandshakeInfo.__lock:
                 if HandshakeInfo.__instance is None:
                     response = await Querier.get_instance().send_post_request(HANDSHAKE, {})
                     HandshakeInfo.__instance = HandshakeInfo(response)
@@ -59,9 +59,8 @@ class HandshakeInfo:
         HandshakeInfo.__instance = None
 
     def update_jwt_signing_public_key_info(self, new_key, new_expiry):
-        with HandshakeInfo.__lock:
-            self.jwt_signing_public_key = new_key
-            self.jwt_signing_public_key_expiry_time = new_expiry
+        self.jwt_signing_public_key = new_key
+        self.jwt_signing_public_key_expiry_time = new_expiry
 
     def get_session_expired_status_code(self):
         return self.session_expired_status_code

--- a/supertokens_fastapi/querier.py
+++ b/supertokens_fastapi/querier.py
@@ -39,7 +39,7 @@ from supertokens_fastapi.device_info import (
 )
 from json import JSONDecodeError
 from os import environ
-from threading import Lock
+from asyncio import Lock
 from httpx import AsyncClient, NetworkError, ConnectTimeout
 from typing import List, Union
 
@@ -76,7 +76,7 @@ class Querier:
         if self.__api_version is not None:
             return self.__api_version
 
-        with Querier.__lock:
+        async with Querier.__lock:
             if self.__api_version is not None:
                 return self.__api_version
 
@@ -96,7 +96,7 @@ class Querier:
                 SUPPORTED_CDI_VERSIONS)
 
             if api_version is None:
-                raise_general_exception('The running SuperTokens core version is not compatible with this Flask SDK. '
+                raise_general_exception('The running SuperTokens core version is not compatible with this FastAPI SDK. '
                                         'Please visit https://supertokens.io/docs/community/compatibility to find the '
                                         'right versions')
 
@@ -106,9 +106,7 @@ class Querier:
     @staticmethod
     def get_instance():
         if Querier.__instance is None:
-            with Querier.__lock:
-                if Querier.__instance is None:
-                    Querier.__instance = Querier()
+            Querier.__instance = Querier()
         return Querier.__instance
 
     @staticmethod


### PR DESCRIPTION
You may notice that I have removed the locks in some places. This was done because FastAPI is single-threaded and there are no IO operations.